### PR TITLE
Remove specified server name

### DIFF
--- a/server/nginx/host.conf
+++ b/server/nginx/host.conf
@@ -3,7 +3,7 @@ upstream php-upstream {
 }
 
 server {
-    server_name symfony.dev;
+    server_name _;
     root /var/projects/symfony/app/web;
 
 


### PR DESCRIPTION
There is only one project inside each container, so it's unfair to define servername here. After this change you can reuse your server config without any changes in all your projects.
